### PR TITLE
First runtime error, because lambda_layer.zip does not exist at first…

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -6,7 +6,7 @@ echo "prepping clamav"
 
 rm -rf bin
 rm -rf lib
-rm lambda_layer.zip
+rm lambda_layer.zip || true
 
 yum update -y
 amazon-linux-extras install epel -y


### PR DESCRIPTION
… run and script breaks.

In the first run, the file lambda_layer.zip  does not exist and the file "build.sh" breaks with 

`rm: cannot remove 'lambda_layer.zip': No such file or directory`

This quick fix helps to ignore the error so the script can continue.