### PR TITLE
bug fix - libxml2, libbz2 libltdl libxma shared objects missing

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -15,12 +15,16 @@ yum install -y cpio yum-utils zip
 # extract binaries for clamav, json-c, pcre
 mkdir -p /tmp/build
 pushd /tmp/build
-yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2
+yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libxml2 bzip2-libs libtool-ltdl xz-libs
 rpm2cpio clamav-0*.rpm | cpio -vimd
 rpm2cpio clamav-lib*.rpm | cpio -vimd
 rpm2cpio clamav-update*.rpm | cpio -vimd
 rpm2cpio json-c*.rpm | cpio -vimd
 rpm2cpio pcre*.rpm | cpio -vimd
+rpm2cpio libxml2*.rpm | cpio -vimd
+rpm2cpio bzip2-libs*.rpm | cpio -vimd
+rpm2cpio libtool-ltdl*.rpm | cpio -vimd
+rpm2cpio xz-libs*.rpm | cpio -vimd
 # reset the timestamps so that we generate a reproducible zip file where
 # running with the same file contents we get the exact same hash even if we
 # run the same build on different days


### PR DESCRIPTION
clamav complained about some shared objects being missing when running. So I added them into the lambda_layer.zip following the pattern that was already in build.sh.

Thankyou very much for this repository it saved me a lot of time.