### PR TITLE
Make the volume mounts work on SELinux-enabled hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ clean:
 
 build: clean
 	docker run --rm -ti \
-		-v `pwd`/build:/opt/app \
+		-v `pwd`/build:/opt/app:Z \
 		amazonlinux:2 \
 		/bin/bash -c "cd /opt/app && ./build.sh"
 .PHONY: build
 
 test-node12:
 	docker run -it --rm \
-		-v `pwd`/build:/opt:ro,delegated \
+		-v `pwd`/build:/opt:ro,delegated,Z \
 		lambci/lambda:build-nodejs12.x \
 		bash
 .PHONY: test-node12


### PR DESCRIPTION
The `:Z` option is needed for SELinux-enabled hosts to apply a suitable (private, unshared)
label to the container mount, allowing the /bin/sh inside the container to actually access
the contents of the /opt/app directory.

See https://prefetch.net/blog/2017/09/30/using-docker-volumes-on-selinux-enabled-servers/
for an in-depth discussion on these flags.