### PR TITLE
Remove the `-ti` switches when running `docker run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 .PHONY: clean
 
 build: clean
-	docker run --rm -ti \
+	docker run --rm \
 		-v `pwd`/build:/opt/app \
 		amazonlinux:2 \
 		/bin/bash -c "cd /opt/app && ./build.sh"


### PR DESCRIPTION
This is intended for a non-interactive build, there is really no point here
to require a TTY or some input capability.

---
In particular: Having the `-ti` here broke building this on AWS CodeBuild, with a "The input device is not a TTY" error from `docker run`.